### PR TITLE
Fix for Issue/6 -- Retro-fuse won't compile on M2 MacBook Pro

### DIFF
--- a/src/fusecommon.c
+++ b/src/fusecommon.c
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
 
     memset(&cfg, 0, sizeof(cfg));
 
-    retrofuse_cmdname = rindex(argv[0], '/');
+    retrofuse_cmdname = strrchr(argv[0], '/');
     if (retrofuse_cmdname == NULL)
         retrofuse_cmdname = argv[0];
     else


### PR DESCRIPTION
Use strrchr() instead of rindex().